### PR TITLE
Use a local reference to the Backbone object.

### DIFF
--- a/backbone_tastypie/static/js/backbone-tastypie.js
+++ b/backbone_tastypie/static/js/backbone-tastypie.js
@@ -6,6 +6,8 @@
  * Add or override Backbone.js functionality, for compatibility with django-tastypie.
  */
 (function( undefined ) {
+	// Backbone.noConflict support. Save local copy of Backbone object.
+	var Backbone = window.Backbone;
 	/**
 	 * Override Backbone's sync function, to do a GET upon receiving a HTTP CREATED.
 	 * This requires 2 requests to do a create, so you may want to use some other method in production.


### PR DESCRIPTION
I wanted to use Backbone in "noConflict" mode so as not to conflict with any other versions of Backbone that might exist on the webpage.
