### PR TITLE
Use id property as id attribute rather than resource_uri

### DIFF
--- a/backbone_tastypie/static/js/backbone-tastypie.js
+++ b/backbone_tastypie/static/js/backbone-tastypie.js
@@ -46,7 +46,7 @@
 				// If create is successful but doesn't return a response, fire an extra GET.
 				// Otherwise, resolve the deferred (which triggers the original 'success' callbacks).
 				if ( !resp && ( xhr.status === 201 || xhr.status === 202 || xhr.status === 204 ) ) { // 201 CREATED, 202 ACCEPTED or 204 NO CONTENT; response null or empty.
-					var location = xhr.getResponseHeader( 'Location' ) || model.id;
+					var location = xhr.getResponseHeader( 'Location' ) || model.url();
 					return $.ajax( {
 						   url: location,
 						   headers: headers,
@@ -73,11 +73,9 @@
 		return Backbone.oldSync( method, model, options );
 	};
 
-	Backbone.Model.prototype.idAttribute = 'resource_uri';
-	
 	Backbone.Model.prototype.url = function() {
 		// Use the id if possible
-		var url = this.id;
+		var url = this.get('resource_uri');
 		
 		// If there's no idAttribute, use the 'urlRoot'. Fallback to try to have the collection construct a url.
 		// Explicitly add the 'id' attribute if the model has one.
@@ -122,7 +120,7 @@
 		// (set to 'resource_uri') contains the model's id.
 		if ( models && models.length ) {
 			var ids = _.map( models, function( model ) {
-					var parts = _.compact( model.id.split( '/' ) );
+					var parts = _.compact( model.url().split( '/' ) );
 					return parts[ parts.length - 1 ];
 				});
 			url += 'set/' + ids.join( ';' ) + '/';

--- a/test/tests.js
+++ b/test/tests.js
@@ -99,7 +99,7 @@ $(document).ready(function() {
 			
 			var dfd = animal.save();
 			dfd.done( function() {
-				equal( animal.id, '/animal/1/' );
+				equal( animal.id, 1 );
 				equal( animal.get( 'id' ), 1 );
 			});
 			
@@ -139,7 +139,7 @@ $(document).ready(function() {
 			
 			var dfd = animal.save();
 			dfd.done( function() {
-				equal( animal.id, '/animal/1/' );
+				equal( animal.id, 1 );
 				equal( animal.get( 'id' ), 1 );
 			});
 			
@@ -213,7 +213,7 @@ $(document).ready(function() {
 			
 			var successCallback = function( model, resp, xhr ) {
 				equal( resp.id, 1 );
-				equal( model.id, '/animal/1/' );
+				equal( model.id, 1 );
 			};
 			
 			// Request with a response


### PR DESCRIPTION
Hi Paul,

I was working through this tutorial using backbone-tastypie but ran into issues because the URLs generated to display details views used the id attribute values but the resource_uri attribute of the models was used when they were added to the collection. So, when I would try to get a model out of the collection by the id, it would return undefined.

I'm not sure if I ran into this because I'm doing something incorrectly, but I forked the code to change it such that the resource_uri attribute isn't used as the id.  This is a backwards incompatible change so if you think it's worth including, I could add some way to configure it.

Thanks,
Meetesh
