### PR TITLE
Allow Model#urlRoot to be defined as a function

### DIFF
--- a/backbone_tastypie/static/js/backbone-tastypie.js
+++ b/backbone_tastypie/static/js/backbone-tastypie.js
@@ -82,7 +82,7 @@
 		// If there's no idAttribute, use the 'urlRoot'. Fallback to try to have the collection construct a url.
 		// Explicitly add the 'id' attribute if the model has one.
 		if ( !url ) {
-			url = this.urlRoot;
+			url = _.isFunction( this.urlRoot ) ? this.urlRoot() : this.urlRoot;
 			url = url || this.collection && ( _.isFunction( this.collection.url ) ? this.collection.url() : this.collection.url );
 
 			if ( url && this.has( 'id' ) ) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -284,6 +284,10 @@ $(document).ready(function() {
 			person.urlRoot = '/person';
 			equal( person.url(), '/person/2/' );
 
+			// Model's urlRoot should work as a function.
+			person.urlRoot = function() { return "/person"; }
+			equal( person.url(), '/person/2/' );
+
 			// If the idAttribute is set, it's used as the uri verbatim.
 			person.set( { resource_uri: '/person/1/' } );
 			equal( person.url(), '/person/1/' );


### PR DESCRIPTION
Hi!

This is just a small fix to allow Model#urlRoot to be defined as a function. Backbone 0.9.0 introduced a change to allow Model#urlRoot to be a function or value – this fixes Model#url to work with both types.
