### PR TITLE
Add Tastypie SessionAuthentication support

### DIFF
--- a/backbone_tastypie/static/js/backbone-tastypie.js
+++ b/backbone_tastypie/static/js/backbone-tastypie.js
@@ -17,7 +17,8 @@
 		apiKey: {
 			username: '',
 			key: ''
-		}
+		},
+		csrfToken: ''
 	};
 
 	/**
@@ -34,6 +35,13 @@
 				'Authorization': 'ApiKey ' + Backbone.Tastypie.apiKey.username + ':' + Backbone.Tastypie.apiKey.key
 			}, options.headers );
 			options.headers = headers;
+		}
+
+		if ( Backbone.Tastypie.csrfToken && Backbone.Tastypie.csrfToken.length ) {
+			headers = _.extend( {
+				'X-CSRFToken': Backbone.Tastypie.csrfToken 
+			}, options.headers );
+			options.headers = headers;		
 		}
 
 		if ( ( method === 'create' && Backbone.Tastypie.doGetOnEmptyPostResponse ) ||

--- a/test/tests.js
+++ b/test/tests.js
@@ -49,7 +49,8 @@ $(document).ready(function() {
 			apiKey: {
 				username: '',
 				key: ''
-			}
+			},
+			csrfToken: ''
 		};
 
 		// Reset last ajax requests
@@ -87,6 +88,26 @@ $(document).ready(function() {
 				
 			ok( window.requests.length === 2 );
 			equal( secondRequest.headers[ 'Authorization' ], 'ApiKey daniel:204db7bcfafb2deb7506b89eb3b9b715b09905c8' );
+		});
+
+		test( "CSRF token sent as an extra header", function() {
+			Backbone.Tastypie.csrfToken = 'J3TxPrDKCIW1z9byQrg0aaHbukYJGEkX'
+
+			var animal = new Animal( { species: 'Panther' } );
+			var emptyResponse = '';
+			var response = { id: 1, 'resource_uri': '/animal/1/' };
+			var xhr = { status: 201, getResponseHeader: function() { return '/animal/1/'; } };
+			
+			var dfd = animal.save();
+
+			equal( dfd.request.headers[ 'X-CSRFToken' ], 'J3TxPrDKCIW1z9byQrg0aaHbukYJGEkX' );
+			
+				// Do the server's job; trigger the success callbacks
+				var secondRequest = dfd.request.success( emptyResponse, 'created', xhr );
+				secondRequest.success( response, 'get', { status: 200 } );
+				
+			ok( window.requests.length === 2 );
+			equal( secondRequest.headers[ 'X-CSRFToken' ], 'J3TxPrDKCIW1z9byQrg0aaHbukYJGEkX' );
 		});
 	
 		test( "Extra GET on creation if the response is empty", function() {


### PR DESCRIPTION
I needed to make use of the SessionAuthentication feature in Tastypie, which requires a CSRF token to be sent as a header.

http://django-tastypie.readthedocs.org/en/latest/authentication_authorization.html#sessionauthentication
