### PR TITLE
Add AMD support using a better method.

### DIFF
--- a/backbone_tastypie/static/js/backbone-tastypie.js
+++ b/backbone_tastypie/static/js/backbone-tastypie.js
@@ -1,25 +1,26 @@
 /**
  * Backbone-tastypie.js 0.2
  * (c) 2011 Paul Uithol
- * 
+ *
  * Backbone-tastypie may be freely distributed under the MIT license.
  * Add or override Backbone.js functionality, for compatibility with django-tastypie.
  * Depends on Backbone (and thus on Underscore as well): https://github.com/documentcloud/backbone.
  */
-(function( undefined ) {
-	"use strict";
-
-	// Backbone and underscore noConflict support. Save local reference to _ and Backbone objects.
-	var _, Backbone;
-	// CommonJS shim
-	if ( typeof window === 'undefined' ) {
-		_ = require( 'underscore' );
-		Backbone = require( 'backbone' );
-	}
-	else {
-		_ = window._;
-		Backbone = window.Backbone;
-	}
+ (function(root, factory) {
+  // Set up Backbone-tastypie appropriately for the environment.
+  if (typeof exports !== 'undefined') {
+    // Node/CommonJS
+    factory(root, require('backbone'), require('underscore'));
+  } else if (typeof define === 'function' && define.amd) {
+    // AMD
+    define(['backbone', 'underscore'], function(Backbone, _) {
+      factory(root, Backbone, _);
+    });
+  } else {
+    // Browser globals
+    factory(root, root.Backbone, root._);
+  }
+}(this, function(root, Backbone, _) {
 
 	Backbone.Tastypie = {
 		doGetOnEmptyPostResponse: true,
@@ -163,4 +164,4 @@
 	var addSlash = function( str ) {
 		return str + ( ( str.length > 0 && str.charAt( str.length - 1 ) === '/' ) ? '' : '/' );
 	};
-})();
+}));

--- a/backbone_tastypie/static/js/backbone-tastypie.js
+++ b/backbone_tastypie/static/js/backbone-tastypie.js
@@ -21,6 +21,7 @@
     factory(root, root.Backbone, root._);
   }
 }(this, function(root, Backbone, _) {
+  "use strict";
 
 	Backbone.Tastypie = {
 		doGetOnEmptyPostResponse: true,


### PR DESCRIPTION
As requested in #7, this pull request adds AMD support this method: PaulUithol/Backbone-relational#57.

It would be great to get this in, since shimming non-AMD libraries that have AMD requirements with RequireJS can get a little hairy.
