### PR TITLE
Fix create in newer Tastypie and jQuery (kipped retro-compatibility)

### DIFF
--- a/backbone_tastypie/static/js/backbone-tastypie.js
+++ b/backbone_tastypie/static/js/backbone-tastypie.js
@@ -66,7 +66,7 @@
 				// If create is successful but doesn't return a response, fire an extra GET.
 				// Otherwise, resolve the deferred (which triggers the original 'success' callbacks).
 				if ( !resp && ( xhr.status === 201 || xhr.status === 202 || xhr.status === 204 ) ) { // 201 CREATED, 202 ACCEPTED or 204 NO CONTENT; response null or empty.
-					var location = xhr.getResponseHeader( 'Location' ) || model.id;
+					var location = xhr.getResponseHeader( 'Location' ) || model.url();
 					return Backbone.ajax({
 						url: location,
 						headers: headers,
@@ -100,8 +100,8 @@
 	Backbone.Model.prototype.idAttribute = 'resource_uri';
 
 	Backbone.Model.prototype.url = function() {
-		// Use the id if possible
-		var url = this.id;
+		// Use the 'resource_uri' if possible
+		var url = this.get( 'resource_uri' );
 
 		// If there's no idAttribute, use the 'urlRoot'. Fallback to try to have the collection construct a url.
 		// Explicitly add the 'id' attribute if the model has one.
@@ -151,7 +151,7 @@
 		// (set to 'resource_uri') contains the model's id.
 		if ( models && models.length ) {
 			var ids = _.map( models, function( model ) {
-				var parts = _.compact( model.id.split( '/' ) );
+				var parts = _.compact( model.url().split( '/' ) );
 				return parts[ parts.length - 1 ];
 			});
 			url += 'set/' + ids.join( ';' ) + '/';

--- a/backbone_tastypie/static/js/backbone-tastypie.js
+++ b/backbone_tastypie/static/js/backbone-tastypie.js
@@ -1,7 +1,7 @@
 /**
  * Backbone-tastypie.js 0.2
  * (c) 2011 Paul Uithol
- * 
+ *
  * Backbone-tastypie may be freely distributed under the MIT license.
  * Add or override Backbone.js functionality, for compatibility with django-tastypie.
  * Depends on Backbone (and thus on Underscore as well): https://github.com/documentcloud/backbone.
@@ -65,8 +65,14 @@
 			options.success = function( resp, textStatus, xhr ) {
 				// If create is successful but doesn't return a response, fire an extra GET.
 				// Otherwise, resolve the deferred (which triggers the original 'success' callbacks).
-				if ( !resp && ( xhr.status === 201 || xhr.status === 202 || xhr.status === 204 ) ) { // 201 CREATED, 202 ACCEPTED or 204 NO CONTENT; response null or empty.
-					var location = xhr.getResponseHeader( 'Location' ) || model.id;
+				if ( xhr.status === 201 || xhr.status === 202 || xhr.status === 204 ) { // 201 CREATED, 202 ACCEPTED or 204 NO CONTENT; response null or empty.
+					var location;
+					if (!resp) {
+						location = xhr.getResponseHeader( 'Location' ) || model.id;
+					}
+					else {
+						location = resp.resource_uri;
+					}
 					return Backbone.ajax({
 						url: location,
 						headers: headers,

--- a/backbone_tastypie/static/js/backbone-tastypie.js
+++ b/backbone_tastypie/static/js/backbone-tastypie.js
@@ -32,6 +32,11 @@
 	};
 
 	/**
+	 * Keep compatibility with 0.9.x Backbone
+	 */
+	var ajax = Backbone.ajax || $.ajax;
+
+	/**
 	 * Override Backbone's sync function, to do a GET upon receiving a HTTP CREATED.
 	 * This requires 2 requests to do a create, so you may want to use some other method in production.
 	 * Modified from http://joshbohde.com/blog/backbonejs-and-django
@@ -73,7 +78,7 @@
 					else {
 						location = resp.resource_uri;
 					}
-					return Backbone.ajax({
+					return ajax({
 						url: location,
 						headers: headers,
 						success: dfd.resolve,

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "backbone-tastypie",
+  "version": "0.2.1",
+  "description": "A small compatibility layer to make backbone.js and django-tastypie work together happily.",
+  "main": "backbone_tastypie/static/js/backbone-tastypie.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PaulUithol/backbone-tastypie.git"
+  },
+  "keywords": [
+    "backbone",
+    "tastypie",
+    "rest",
+    "django"
+  ],
+  "author": "Paul Uithol",
+  "license": "MIT license",
+  "bugs": {
+    "url": "https://github.com/PaulUithol/backbone-tastypie/issues"
+  },
+  "homepage": "https://github.com/PaulUithol/backbone-tastypie"
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -132,7 +132,7 @@ $(document).ready(function() {
 				
 			ok( window.requests.length === 2 );
 			equal( _.last( window.requests ).headers[ 'Authorization' ], 'ApiKey daniel:204db7bcfafb2deb7506b89eb3b9b715b09905c8' );
-			ok( animal.id === '/animal/1/' );
+			equal( animal.id, '/animal/1/' );
 		});
 
 		test( "CSRF token sent as an extra header", function() {


### PR DESCRIPTION
Fixes the CREATE method when django-tastypie response only using the page status without a body content;
Make it compatible with old backbone version (0.9.x or older)
Add package.json to be able to use npm install for this package
