### PR TITLE
zip_safe is False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,4 +35,5 @@ setup(
     url='https://github.com/PaulUithol',
     packages=['backbone_tastypie'],
     package_data={'backbone_tastypie': data_files},
+    zip_safe=False,
 )


### PR DESCRIPTION
In setup.py you should use zip_safe=False so that easy_install will unzip the static files.
